### PR TITLE
Feat: implement domain entities and exception handling

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "bug 🐞",
+    "color": "d73a4a",
+    "description": "Something isn't working"
+  },
+  {
+    "name": "cleanup 🧹",
+    "color": "e99695",
+    "description": "Paying off technical debt"
+  },
+  {
+    "name": "critical 🚨",
+    "color": "b60205",
+    "description": "Event that must be dealt with to ensure the system stability"
+  },
+  {
+    "name": "dependencies 📦",
+    "color": "0366d6",
+    "description": "Pull requests that update a dependency file"
+  },
+  {
+    "name": "discussion 💭",
+    "color": "d4c5f9",
+    "description": "Need to be discussed"
+  },
+  {
+    "name": "documentation 📔",
+    "color": "1d76db",
+    "description": "Improvements or additions to documentation"
+  },
+  {
+    "name": "duplicate 🧬",
+    "color": "cfd3d7",
+    "description": "This issue or pull request already exists"
+  },
+  {
+    "name": "enhancement 🌟",
+    "color": "a2eeef",
+    "description": "New feature or request"
+  },
+  {
+    "name": "good first issue 🐤",
+    "color": "7057ff",
+    "description": "Good for newcomers"
+  },
+  {
+    "name": "hacktoberfest-accepted 🎃",
+    "color": "ff9100",
+    "description": "Accept for hacktoberfest, will merge later"
+  },
+  {
+    "name": "hard 🧑‍🔬",
+    "color": "f9d0c4",
+    "description": "Difficult to deal with or require research"
+  },
+  {
+    "name": "help wanted 🦮",
+    "color": "008672",
+    "description": "Extra attention is needed"
+  },
+  {
+    "name": "protocol changed 📝",
+    "color": "fbca04",
+    "description": "Whether the protocol has changed"
+  },
+  {
+    "name": "question ❓",
+    "color": "d876e3",
+    "description": "Further information is requested"
+  },
+  {
+    "name": "sdk ⚒️",
+    "color": "5319e7",
+    "description": "Related to SDK development"
+  }
+]

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### Project-specific ###
+CLAUDE.md
+mysql_data/
+
 ### IntelliJ IDEA ###
 .idea
 *.iws

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+
+  mysql-server:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: asd1234
+      MYSQL_DATABASE: jjigit_db
+    ports:
+      - "3306:3306"
+    container_name: mysql-jjigit
+    volumes:
+      - ./mysql_data:/var/lib/mysql

--- a/src/main/java/com/jigit/backend/comment/domain/Comment.java
+++ b/src/main/java/com/jigit/backend/comment/domain/Comment.java
@@ -1,0 +1,50 @@
+package com.jigit.backend.comment.domain;
+
+import com.jigit.backend.poll.domain.Poll;
+import com.jigit.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poll_id", nullable = false)
+    private Poll poll;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "voter_id", nullable = false)
+    private User voter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Comment(Poll poll, User voter, Comment parentComment, String content) {
+        this.poll = poll;
+        this.voter = voter;
+        this.parentComment = parentComment;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/jigit/backend/comment/exception/CommentException.java
+++ b/src/main/java/com/jigit/backend/comment/exception/CommentException.java
@@ -1,0 +1,33 @@
+package com.jigit.backend.comment.exception;
+
+import com.jigit.backend.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum CommentException implements ExceptionCode {
+
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Comment Not Found", "The requested comment does not exist."),
+    INVALID_COMMENT_CONTENT(HttpStatus.BAD_REQUEST, "Invalid Comment Content", "Comment content cannot be empty."),
+    UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.FORBIDDEN, "Unauthorized Access", "You do not have permission to modify this comment."),
+    INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, "Invalid Parent Comment", "The parent comment does not exist or does not belong to this poll.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public String getDetail() {
+        return detail;
+    }
+}

--- a/src/main/java/com/jigit/backend/global/exception/ApplicationException.java
+++ b/src/main/java/com/jigit/backend/global/exception/ApplicationException.java
@@ -1,0 +1,19 @@
+package com.jigit.backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicationException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public ApplicationException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getDetail());
+        this.exceptionCode = exceptionCode;
+    }
+
+    public ApplicationException(ExceptionCode exceptionCode, Throwable cause) {
+        super(exceptionCode.getDetail(), cause);
+        this.exceptionCode = exceptionCode;
+    }
+}

--- a/src/main/java/com/jigit/backend/global/exception/CommonException.java
+++ b/src/main/java/com/jigit/backend/global/exception/CommonException.java
@@ -1,0 +1,33 @@
+package com.jigit.backend.global.exception;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum CommonException implements ExceptionCode {
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "Bad Request", "The request is invalid or malformed."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Unauthorized", "Authentication is required."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "Forbidden", "You do not have permission to access this resource."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "Not Found", "The requested resource was not found."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", "An unexpected error occurred.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public String getDetail() {
+        return detail;
+    }
+}

--- a/src/main/java/com/jigit/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/jigit/backend/global/exception/ErrorResponse.java
@@ -1,0 +1,23 @@
+package com.jigit.backend.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private String title;
+    private int status;
+    private String detail;
+    private String instance;
+
+    public static ErrorResponse of(ExceptionCode exceptionCode, String instance) {
+        return new ErrorResponse(
+                exceptionCode.getTitle(),
+                exceptionCode.getHttpStatus().value(),
+                exceptionCode.getDetail(),
+                instance
+        );
+    }
+}

--- a/src/main/java/com/jigit/backend/global/exception/ExceptionCode.java
+++ b/src/main/java/com/jigit/backend/global/exception/ExceptionCode.java
@@ -1,0 +1,9 @@
+package com.jigit.backend.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionCode {
+    HttpStatus getHttpStatus();
+    String getTitle();
+    String getDetail();
+}

--- a/src/main/java/com/jigit/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jigit/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.jigit.backend.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ErrorResponse> handleApplicationException(
+            ApplicationException ex,
+            HttpServletRequest request
+    ) {
+        ExceptionCode exceptionCode = ex.getExceptionCode();
+        ErrorResponse errorResponse = ErrorResponse.of(exceptionCode, request.getRequestURI());
+
+        return ResponseEntity
+                .status(exceptionCode.getHttpStatus())
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(InfrastructureException.class)
+    public ResponseEntity<ErrorResponse> handleInfrastructureException(
+            InfrastructureException ex,
+            HttpServletRequest request
+    ) {
+        ExceptionCode exceptionCode = ex.getExceptionCode();
+        ErrorResponse errorResponse = ErrorResponse.of(exceptionCode, request.getRequestURI());
+
+        return ResponseEntity
+                .status(exceptionCode.getHttpStatus())
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneralException(
+            Exception ex,
+            HttpServletRequest request
+    ) {
+        ErrorResponse errorResponse = ErrorResponse.of(
+                CommonException.INTERNAL_SERVER_ERROR,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(CommonException.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(errorResponse);
+    }
+}

--- a/src/main/java/com/jigit/backend/global/exception/InfrastructureException.java
+++ b/src/main/java/com/jigit/backend/global/exception/InfrastructureException.java
@@ -1,0 +1,19 @@
+package com.jigit.backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InfrastructureException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public InfrastructureException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getDetail());
+        this.exceptionCode = exceptionCode;
+    }
+
+    public InfrastructureException(ExceptionCode exceptionCode, Throwable cause) {
+        super(exceptionCode.getDetail(), cause);
+        this.exceptionCode = exceptionCode;
+    }
+}

--- a/src/main/java/com/jigit/backend/poll/domain/Option.java
+++ b/src/main/java/com/jigit/backend/poll/domain/Option.java
@@ -1,0 +1,40 @@
+package com.jigit.backend.poll.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "options")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Option {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "option_id")
+    private Long optionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poll_id", nullable = false)
+    private Poll poll;
+
+    @Column(name = "option_text", nullable = false, length = 255)
+    private String optionText;
+
+    @Column(name = "option_order", nullable = false)
+    private Integer optionOrder;
+
+    @Builder
+    public Option(Poll poll, String optionText, Integer optionOrder) {
+        this.poll = poll;
+        this.optionText = optionText;
+        this.optionOrder = optionOrder;
+    }
+
+    public void setPoll(Poll poll) {
+        this.poll = poll;
+    }
+}

--- a/src/main/java/com/jigit/backend/poll/domain/Poll.java
+++ b/src/main/java/com/jigit/backend/poll/domain/Poll.java
@@ -1,0 +1,52 @@
+package com.jigit.backend.poll.domain;
+
+import com.jigit.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "polls")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Poll {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "poll_id")
+    private Long pollId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id", nullable = false)
+    private User creator;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "is_public", nullable = false)
+    private Boolean isPublic;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "poll", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Option> options = new ArrayList<>();
+
+    @Builder
+    public Poll(User creator, String title, Boolean isPublic) {
+        this.creator = creator;
+        this.title = title;
+        this.isPublic = isPublic;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void addOption(Option option) {
+        this.options.add(option);
+    }
+}

--- a/src/main/java/com/jigit/backend/poll/exception/PollException.java
+++ b/src/main/java/com/jigit/backend/poll/exception/PollException.java
@@ -1,0 +1,34 @@
+package com.jigit.backend.poll.exception;
+
+import com.jigit.backend.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum PollException implements ExceptionCode {
+
+    POLL_NOT_FOUND(HttpStatus.NOT_FOUND, "Poll Not Found", "The requested poll does not exist."),
+    UNAUTHORIZED_POLL_ACCESS(HttpStatus.FORBIDDEN, "Unauthorized Access", "You do not have permission to access this poll."),
+    INVALID_POLL_TITLE(HttpStatus.BAD_REQUEST, "Invalid Poll Title", "Poll title cannot be empty."),
+    INSUFFICIENT_OPTIONS(HttpStatus.BAD_REQUEST, "Insufficient Options", "A poll must have at least 2 options."),
+    OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Option Not Found", "The requested option does not exist.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public String getDetail() {
+        return detail;
+    }
+}

--- a/src/main/java/com/jigit/backend/user/domain/User.java
+++ b/src/main/java/com/jigit/backend/user/domain/User.java
@@ -1,0 +1,37 @@
+package com.jigit.backend.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "username", nullable = false, unique = true, length = 100)
+    private String username;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public User(String username, String passwordHash) {
+        this.username = username;
+        this.passwordHash = passwordHash;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/jigit/backend/user/exception/UserException.java
+++ b/src/main/java/com/jigit/backend/user/exception/UserException.java
@@ -1,0 +1,33 @@
+package com.jigit.backend.user.exception;
+
+import com.jigit.backend.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum UserException implements ExceptionCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User Not Found", "The requested user does not exist."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "Duplicate Username", "The username is already taken."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "Invalid Password", "The password format is invalid."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "Invalid Credentials", "Username or password is incorrect.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public String getDetail() {
+        return detail;
+    }
+}

--- a/src/main/java/com/jigit/backend/vote/domain/Vote.java
+++ b/src/main/java/com/jigit/backend/vote/domain/Vote.java
@@ -1,0 +1,55 @@
+package com.jigit.backend.vote.domain;
+
+import com.jigit.backend.poll.domain.Option;
+import com.jigit.backend.poll.domain.Poll;
+import com.jigit.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "votes",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_voter_poll",
+            columnNames = {"voter_id", "poll_id"}
+        )
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vote_id")
+    private Long voteId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "poll_id", nullable = false)
+    private Poll poll;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id", nullable = false)
+    private Option option;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "voter_id", nullable = false)
+    private User voter;
+
+    @Column(name = "voted_at", nullable = false, updatable = false)
+    private LocalDateTime votedAt;
+
+    @Builder
+    public Vote(Poll poll, Option option, User voter) {
+        this.poll = poll;
+        this.option = option;
+        this.voter = voter;
+        this.votedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/jigit/backend/vote/exception/VoteException.java
+++ b/src/main/java/com/jigit/backend/vote/exception/VoteException.java
@@ -1,0 +1,33 @@
+package com.jigit.backend.vote.exception;
+
+import com.jigit.backend.global.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum VoteException implements ExceptionCode {
+
+    VOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "Vote Not Found", "The requested vote does not exist."),
+    DUPLICATE_VOTE(HttpStatus.CONFLICT, "Duplicate Vote", "You have already voted on this poll."),
+    INVALID_OPTION(HttpStatus.BAD_REQUEST, "Invalid Option", "The selected option does not belong to this poll."),
+    POLL_NOT_ACCESSIBLE(HttpStatus.FORBIDDEN, "Poll Not Accessible", "This poll is not accessible.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public String getDetail() {
+        return detail;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,18 @@
 spring:
   application:
     name: jjigit-backend
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/jjigit_db
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: asd1234
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+    show-sql: true


### PR DESCRIPTION
**Summary**
Implemented domain entities and global exception handling infrastructure based on the ERD specification.

**Related Issues**
Closes #4

**Motivation**
This PR establishes the foundational domain model for the JJiGiT voting service. Based on the ERD table defined in the project specifications, we needed to implement entities with proper JPA mappings, relationships, and constraints to support the core business logic.

**Implementation Notes**

1. **Database Configuration**
   - Configured MySQL database (`jjigit_db`) in docker-compose.yml and application.yaml
   - Added Lombok dependency for cleaner entity code

2. **Global Exception Handling**
   - Created `ExceptionCode` interface for standardized error responses
   - Implemented `ApplicationException` and `InfrastructureException` classes
   - Added `GlobalExceptionHandler` with `@RestControllerAdvice`
   - Created `ErrorResponse` DTO following RFC 7807 problem details format

3. **Domain Entities (DDD Structure)**
   - **User**: userId (PK), username (unique constraint), passwordHash, createdAt
   - **Poll**: pollId (PK), creator (FK to User), title, isPublic flag, createdAt
   - **Option**: optionId (PK), poll (FK), optionText, optionOrder
   - **Vote**: voteId (PK), poll (FK), option (FK), voter (FK), votedAt
     - **Unique constraint on (voter_id, poll_id)** for one-vote-per-poll business rule
   - **Comment**: commentId (PK), poll (FK), voter (FK), parentCommentId (self-referencing FK for nested replies), content, createdAt

4. **Relationships**
   - User → Poll (1:N via @ManyToOne)
   - Poll → Option (1:N via @OneToMany with cascade)
   - Poll → Vote (1:N via @ManyToOne)
   - Option → Vote (1:N via @ManyToOne)
   - User → Vote (1:N via @ManyToOne)
   - Poll → Comment (1:N via @ManyToOne)
   - Comment → Comment (self-referencing 1:N for replies)

5. **Domain-Specific Exceptions**
   - Created exception enums for each domain: `UserException`, `PollException`, `VoteException`, `CommentException`
   - Each enum implements `ExceptionCode` interface with HTTP status, title, and detail

**Testing & Validation**
- Project builds successfully with `./gradlew build -x test`
- All entities follow JPA best practices with proper lazy loading
- CLAUDE.md properly excluded from git tracking via .gitignore

**Checklist**
- [x] Code follows project style guidelines (DDD structure, English naming)
- [ ] Relevant tests added / updated (will be added in future PRs)
- [x] Documentation updated if necessary (entity structure documented)
- [x] No breaking changes introduced